### PR TITLE
Clarified `dhcp-identifier` option

### DIFF
--- a/doc/netplan.md
+++ b/doc/netplan.md
@@ -192,9 +192,10 @@ Virtual devices
 
 ``dhcp-identifier`` (scalar)
 
-:   When set to 'mac'; pass that setting over to systemd-networkd to use the
-    device's MAC address as a unique identifier rather than a RFC4361-compliant
-    Client ID. This has no effect when NetworkManager is used as a renderer.
+:   (networkd backend only) Sets the source of DHCPv4 client identifier. If "mac"
+    is specified, the MAC address of the link is used. If this option is omitted,
+    or if "duid" is specified, networkd will generate an RFC4361-compliant client
+    identifier for the interface by combining the link's IAID and DUID.
 
  ``dhcp4-overrides`` (mapping)
 


### PR DESCRIPTION
## Description
Added information about the other accepted scalar "duid" which can be specified or is assumed if the option is omitted entirely.

## Checklist

- [x] Runs `make check` successfully.
- [x] Retains 100% code coverage (`make check-coverage`).
- [x] New/changed keys in YAML format are documented.
- [ ] \(Optional\) Closes an open bug in Launchpad.

